### PR TITLE
Restrict deploys to authorized users

### DIFF
--- a/upchieve_chatbot.rb
+++ b/upchieve_chatbot.rb
@@ -6,6 +6,11 @@ class UPchieveChatbot < Sinatra::Base
   post "/deploy" do
     return "Unauthorized" if params[:key] != ENV["SLACK_WEBHOOK_KEY"]
 
+    deploy_channel = ENV["SLACK_DEPLOYMENT_CHANNEL"] || "tech-chatops"
+    unless params[:channel_name] == deploy_channel
+      return "Deployments must be triggered from ##{deploy_channel}."
+    end
+
     user_id = params[:user_id]
     environment = params[:command].to_s.scan(/deploy-(.+)/).flatten.first
     args = params[:text].to_s.split


### PR DESCRIPTION
Before initiating a deploy, check to see what channel it was initiated from. If not from `deploy_channel`, halt and respond with an explanatory message.

The deployment channel can be customized per-environment by setting the env var `SLACK_DEPLOYMENT_CHANNEL` on the corresponding node (defaults to `#tech-chatops` on both.)

Deploys can be restricted to a subset of Slack users by making the deployment channel private / invitation-only. https://slack.com/help/articles/213185467